### PR TITLE
Makefile: Add OPTS variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 travis:
-	cd travis && docker build -t linuxbrew/travis .
+	cd travis && docker build -t linuxbrew/travis $(OPTS) .
 
 ubuntu:
-	cd ubuntu && docker build -t linuxbrew/ubuntu .
+	cd ubuntu && docker build -t linuxbrew/ubuntu $(OPTS) .
 
 .PHONY: travis ubuntu


### PR DESCRIPTION
This allows you to add any flag supported by `docker build` to the build commands. Disabling the cache with `--no-cache=true` is by far the most useful.