### PR TITLE
Use labels instead of deprecated MAINTAINER instructions

### DIFF
--- a/travis/Dockerfile
+++ b/travis/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/travisci/travis-ruby
-MAINTAINER Bob W. Hogg <rwhogg@linux.com>
+LABEL maintainer="Bob W. Hogg <rwhogg@linux.com>"
 
 RUN sudo apt-get -qq update &&\
     sudo apt-get install -y libxml-parser-perl libxml-sax-perl &&\

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:xenial
-MAINTAINER Shaun Jackman <sjackman@gmail.com>
+LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 
 RUN apt-get update \
-	&& apt-get install -y curl file g++ git make ruby2.3 ruby2.3-dev uuid-runtime \
+	&& apt-get install -y curl file g++ git locales make ruby2.3 ruby2.3-dev uuid-runtime \
 	&& ln -sf ruby2.3 /usr/bin/ruby \
 	&& ln -sf gem2.3 /usr/bin/gem
 


### PR DESCRIPTION
Also, apparently the Ubuntu image refused to build without
installing the locales package...

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>