### PR TITLE
Fix broken brew audit in debian image

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 ENV LANG en_US.UTF-8
 
 # Install minimal debian packages listed in Linuxbrew documentation
-RUN apt-get install -y build-essential curl file git python-setuptools ruby
+RUN apt-get install -y build-essential curl file git python-setuptools
 
 # Create a linuxbrew user
 RUN  useradd -m -s /bin/bash linuxbrew \
@@ -25,3 +25,6 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 
 # Install Linuxbrew from github
 RUN git clone https://github.com/Linuxbrew/brew.git .linuxbrew
+
+# Install portable-ruby by running brew a first time
+RUN brew list

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -25,6 +25,3 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 
 # Install Linuxbrew from github
 RUN git clone https://github.com/Linuxbrew/brew.git .linuxbrew
-
-# Install ruby from Linuxbrew
-RUN brew install ruby

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -25,3 +25,6 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 
 # Install Linuxbrew from github
 RUN git clone https://github.com/Linuxbrew/brew.git .linuxbrew
+
+# Install ruby from Linuxbrew
+RUN brew install ruby

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -26,5 +26,5 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 # Install Linuxbrew from github
 RUN git clone https://github.com/Linuxbrew/brew.git .linuxbrew
 
-# Install portable-ruby by running brew a first time
-RUN brew list
+# Install portable-ruby by running brew for the first time
+RUN brew doctor


### PR DESCRIPTION
On a fresh Linuxbrew debian image running `brew audit` on a formula gives:
```
linuxbrew@9e93cefe5a31:~$ brew audit htop
==> Installing or updating 'rubocop' gem
Fetching: rainbow-2.2.2.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing rubocop:
	ERROR: Failed to build gem native extension.

    current directory: /home/linuxbrew/.gem/ruby/2.3.0/gems/rainbow-2.2.2/ext
/usr/bin/ruby2.3 mkrf_conf.rb

current directory: /home/linuxbrew/.gem/ruby/2.3.0/gems/rainbow-2.2.2/ext
/usr/bin/ruby2.3 -rubygems /usr/share/rubygems-integration/all/gems/rake-10.5.0/bin/rake RUBYARCHDIR=/home/linuxbrew/.gem/ruby/2.3.0/extensions/x86_64-linux/2.3.0/rainbow-2.2.2 RUBYLIBDIR=/home/linuxbrew/.gem/ruby/2.3.0/extensions/x86_64-linux/2.3.0/rainbow-2.2.2
/usr/bin/ruby2.3: No such file or directory -- /usr/share/rubygems-integration/all/gems/rake-10.5.0/bin/rake (LoadError)

rake failed, exit code 1

Gem files will remain installed in /home/linuxbrew/.gem/ruby/2.3.0/gems/rainbow-2.2.2 for inspection.
Results logged to /home/linuxbrew/.gem/ruby/2.3.0/extensions/x86_64-linux/2.3.0/rainbow-2.2.2/gem_make.out
Error: Failed to install/update the 'rubocop' gem.
```

After installing the linuxbrew ruby version, the error disappear. I propose to add 
```
RUN brew install ruby
```
in the Dockerfile.

P.S.: 
* Linuxbrew Ruby version = 2.4.1p111 
* Debian Stretch Ruby version = 2.3.3p222