### PR TITLE
Set dummy Git names on Debian and Ubuntu

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -26,5 +26,8 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 # Install Linuxbrew from github
 RUN git clone https://github.com/Linuxbrew/brew.git .linuxbrew
 
+RUN git config --global user.name "Linuxbrew User" &&\
+    git config --global user.email "linuxbrew@linuxbrew.sh"
+
 # Install portable-ruby by running brew for the first time
 RUN brew doctor

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -13,6 +13,9 @@ WORKDIR /home/linuxbrew
 
 RUN git clone https://github.com/Linuxbrew/brew.git .linuxbrew
 
+RUN git config --global user.name "Linuxbrew User" &&\
+    git config --global user.email "linuxbrew@linuxbrew.sh"
+
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 	SHELL=/bin/bash
 


### PR DESCRIPTION
Fix error:
fatal: empty ident name (for <linuxbrew@6141ff4618df.(none)>)

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

The failure comes from trying to use Git during the update report.