### PR TITLE
travis: Remove libjpeg8-dev

### DIFF
--- a/travis/Dockerfile
+++ b/travis/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get -qq update &&\
       libjack0\
       libjasper-dev\
       libjbig-dev\
+      libjpeg8-dev\
       libkrb5-dev\
       libldap2-dev\
       libltdl-dev\


### PR DESCRIPTION
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

This was removed from core in https://github.com/Linuxbrew/homebrew-core/pull/3702