### PR TITLE
travis: Add Linuxbrew to sudoers list

### DIFF
--- a/travis/Dockerfile
+++ b/travis/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get -qq update &&\
 
 # Get to the right place
 RUN useradd -ms /bin/bash linuxbrew
+RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 USER linuxbrew
 WORKDIR /home/linuxbrew
 


### PR DESCRIPTION
While not matching the Travis environment as closely,
it does have the advantage of easier experimentation,
which I feel is more useful.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>