### PR TITLE
travis: Use latest tag for base image

### DIFF
--- a/travis/Dockerfile
+++ b/travis/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/travisci/travis-ruby
+FROM quay.io/travisci/travis-ruby:latest
 LABEL maintainer="Bob W. Hogg <rwhogg@linux.com>"
 
 RUN apt-get -qq update &&\


### PR DESCRIPTION
Sure, the linter isn't any happier, but I'd argue it's
still an improvement.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>