### PR TITLE
LICENSE.txt: Use "present" instead of 2017

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2009-2017, Homebrew contributors
+Copyright (c) 2009-present, Homebrew contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Use the same license text as brew.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>