### PR TITLE
Follow dockerfilelint recommendations for Debian image

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -5,18 +5,17 @@ LABEL name="Linuxbrew/debian"
 # Set apt in non-interactive mode during the image build
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Install minimal debian packages listed in Linuxbrew documentation
 # Set up UTF-8
 RUN apt-get update && \
-    apt-get install -y apt-utils locales && \
+    apt-get install -y --no-install-recommends ca-certificates locales \
+    build-essential curl file git python-setuptools && \
     apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
     sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure locales && \
     update-locale LANG=en_US.UTF-8
 ENV LANG en_US.UTF-8
-
-# Install minimal debian packages listed in Linuxbrew documentation
-RUN apt-get install -y build-essential curl file git python-setuptools \
-  && apt-get clean
 
 # Create a linuxbrew user
 RUN  useradd -m -s /bin/bash linuxbrew \


### PR DESCRIPTION
For the Debian image, dockerfilelint was complaining about two things:

1. - > Consider using a `--no-install-recommends` when `apt-get` installing packages.  This will result in a smaller image size. For more information, see [this blog post](http://blog.replicated.com/2016/02/05/refactoring-a-dockerfile-for-image-size/)

For this I have:
 - added the `--no-install-recommends` option. 
 - explicitly added the ca-certificates debian package, needed for the https connection to github.

2. - >Use of apt-get update should be paired with rm -rf /var/lib/apt/lists/* in the same layer. Consider using a `--no-install-recommends` when `apt-get` installing packages.  This will result in a smaller image size. For more information, see [this blog post](http://blog.replicated.com/2016/02/05/refactoring-a-dockerfile-for-image-size/)

For this I have:
 - Added the rm -rf /var/lib/apt/lists/* command

I have also:
-  merged the two apt-get install commands
- removed the apt-utils debian package which is only useful for removing a warning but has no real usage. See discussion here: https://github.com/docker-library/php/issues/532 