### PR TITLE
Follow dockerfilelint recommendations for Ubuntu Xenial Xerus image

### DIFF
--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -1,10 +1,13 @@
 FROM ubuntu:xenial
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="Linuxbrew/xenial"
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-	&& apt-get install -y curl file g++ git locales make uuid-runtime \
-	&& apt-get clean
+	&& apt-get install -y --no-install-recommends \
+                   curl ca-certificates file g++ git locales make uuid-runtime \
+	&& apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
 	&& useradd -m -s /bin/bash linuxbrew \


### PR DESCRIPTION
Follow two dockerfilelint recommendations:

1.  >Use of apt-get update should be paired with rm -rf /var/lib/apt/lists/* in the same layer.

For this I have:

 - added the rm -rf /var/lib/apt/lists/* command


2.  >Consider using a `--no-install-recommends` when `apt-get` installing packages.  This will result in a smaller image size. For more information, see [this blog post](http://blog.replicated.com/2016/02/05/refactoring-a-dockerfile-for-image-size/)

For this I have:
 - added the --no-install-recommends option.
 - explicitly added the ca-certificates debian package, needed for the https connection to github.

I've also added a missing `ARG DEBIAN_FRONTEND=noninteractive` command.