### PR TITLE
Remove python-setuptools debian package from debian image

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Set up UTF-8
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates locales \
-    build-essential curl file git python-setuptools && \
+    build-essential curl file git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \


### PR DESCRIPTION
According to this [discussion](https://github.com/Linuxbrew/docker/pull/37) the debian package python-setuptools is no more needed in the debian image. 