### PR TITLE
Remove sudo from all images

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,9 +3,8 @@ LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="Linuxbrew/alpine"
 
 RUN apk update \
-	&& apk --no-cache add bash curl file git libc6-compat make ruby ruby-irb ruby-json ruby-test-unit sudo \
-	&& adduser -D -s /bin/bash linuxbrew \
-	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+	&& apk --no-cache add bash curl file git libc6-compat make ruby ruby-irb ruby-json ruby-test-unit \
+	&& adduser -D -s /bin/bash linuxbrew
 
 USER linuxbrew
 WORKDIR /home/linuxbrew

--- a/centos5/Dockerfile
+++ b/centos5/Dockerfile
@@ -5,12 +5,11 @@ LABEL name="Linuxbrew/centos5"
 # Fix yum. CentOS 5 is end-of-life as of 2017-03-31.
 RUN urlgrabber https://gist.github.com/sjackman/132b65c33b62a89c45671e9c605025bc/raw/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo \
 	&& urlgrabber https://gist.github.com/sjackman/132b65c33b62a89c45671e9c605025bc/raw/libselinux.repo /etc/yum.repos.d/libselinux.repo \
-	&& yum install -y curl gcc gcc44 gcc44-c++ make sudo which \
+	&& yum install -y curl gcc gcc44 gcc44-c++ make which \
 	&& yum clean all
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
-	&& useradd -m -s /bin/bash linuxbrew \
-	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+	&& useradd -m -s /bin/bash linuxbrew
 
 USER linuxbrew
 WORKDIR /home/linuxbrew

--- a/centos6/Dockerfile
+++ b/centos6/Dockerfile
@@ -2,12 +2,11 @@ FROM centos:6
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="Linuxbrew/centos6"
 
-RUN yum install -y curl make sudo which \
+RUN yum install -y curl make which \
   && yum clean all
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
-	&& useradd -m -s /bin/bash linuxbrew \
-	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+	&& useradd -m -s /bin/bash linuxbrew
 
 USER linuxbrew
 WORKDIR /home/linuxbrew

--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -2,12 +2,11 @@ FROM centos:7
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="Linuxbrew/centos7"
 
-RUN yum install -y curl make ruby sudo which \
+RUN yum install -y curl make ruby which \
   && yum clean all
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
-	&& useradd -m -s /bin/bash linuxbrew \
-	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+	&& useradd -m -s /bin/bash linuxbrew
 
 USER linuxbrew
 WORKDIR /home/linuxbrew

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -18,8 +18,7 @@ RUN apt-get update && \
 ENV LANG en_US.UTF-8
 
 # Create a linuxbrew user
-RUN  useradd -m -s /bin/bash linuxbrew \
-     && echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+RUN  useradd -m -s /bin/bash linuxbrew
 USER linuxbrew
 WORKDIR /home/linuxbrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -2,11 +2,10 @@ FROM fedora:26
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="Linuxbrew/fedora"
 
-RUN dnf install -y curl git glibc-locale-source make ruby rubygem-json rubygem-test-unit sudo which \
+RUN dnf install -y curl git glibc-locale-source make ruby rubygem-json rubygem-test-unit which \
   && dnf clean all \
 	&& localedef -i en_US -f UTF-8 en_US.UTF-8 \
-	&& useradd -m -s /bin/bash linuxbrew \
-	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+	&& useradd -m -s /bin/bash linuxbrew
 
 USER linuxbrew
 WORKDIR /home/linuxbrew

--- a/opensuse/Dockerfile
+++ b/opensuse/Dockerfile
@@ -2,10 +2,9 @@ FROM opensuse:leap
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="Linuxbrew/opensuse"
 
-RUN zypper --non-interactive install curl git glibc-i18ndata glibc-locale make sudo tar which \
+RUN zypper --non-interactive install curl git glibc-i18ndata glibc-locale make tar which \
 	&& localedef -i en_US -f UTF-8 en_US.UTF-8 \
-	&& useradd -m -s /bin/bash linuxbrew \
-	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+	&& useradd -m -s /bin/bash linuxbrew
 
 USER linuxbrew
 WORKDIR /home/linuxbrew

--- a/precise/Dockerfile
+++ b/precise/Dockerfile
@@ -3,11 +3,10 @@ LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="Linuxbrew/precise"
 
 RUN apt-get update \
-	&& apt-get install -y curl file g++ gawk git make sudo uuid-runtime \
+	&& apt-get install -y curl file g++ gawk git make uuid-runtime \
 	&& apt-get-clean \
 	&& localedef -i en_US -f UTF-8 en_US.UTF-8 \
-	&& useradd -m -s /bin/bash linuxbrew \
-	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+	&& useradd -m -s /bin/bash linuxbrew
 
 USER linuxbrew
 WORKDIR /home/linuxbrew

--- a/travis/Dockerfile
+++ b/travis/Dockerfile
@@ -51,7 +51,6 @@ RUN apt-get -qq update &&\
 
 # Get to the right place
 RUN useradd -ms /bin/bash linuxbrew
-RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 USER linuxbrew
 WORKDIR /home/linuxbrew
 

--- a/trusty/Dockerfile
+++ b/trusty/Dockerfile
@@ -3,11 +3,10 @@ LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="Linuxbrew/trusty"
 
 RUN apt-get update \
-	&& apt-get install -y curl file g++ gawk git make sudo uuid-runtime \
+	&& apt-get install -y curl file g++ gawk git make uuid-runtime \
 	&& apt-get clean \
 	&& localedef -i en_US -f UTF-8 en_US.UTF-8 \
-	&& useradd -m -s /bin/bash linuxbrew \
-	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+	&& useradd -m -s /bin/bash linuxbrew
 
 USER linuxbrew
 WORKDIR /home/linuxbrew

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -10,8 +10,7 @@ RUN apt-get update \
         && rm -rf /var/lib/apt/lists/*
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
-	&& useradd -m -s /bin/bash linuxbrew \
-	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+	&& useradd -m -s /bin/bash linuxbrew
 
 USER linuxbrew
 WORKDIR /home/linuxbrew


### PR DESCRIPTION
According to dockerfilelint:

>Use of `sudo` is not allowed in a Dockerfile.  From the official document [Best practices for writing Dockerfiles](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/):
> - You should avoid installing or using `sudo` since it has unpredictable TTY and signal-forwarding behavior that can cause more problems than it solves.
> - If you absolutely need functionality similar to `sudo` (e.g., initializing the daemon as root but running it as non-root), you may be able to use `gosu`.

As Linuxbrew does not need root access this should not be a problem.