### PR TITLE
README.md: fix instructions for provided Dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Dockerfiles for using Linuxbrew on various distributions of Linux.
   ```
 + CentOS 5
   ```sh
-  docker build -t linuxbrew-centos5 https://raw.githubusercontent.com/Linuxbrew/docker/master/centos5/
+  docker build -t linuxbrew-centos5 https://raw.githubusercontent.com/Linuxbrew/docker/master/centos5/Dockerfile
   ```
 + CentOS 6
   ```sh
-  docker build -t linuxbrew-centos6 https://raw.githubusercontent.com/Linuxbrew/docker/master/centos6/
+  docker build -t linuxbrew-centos6 https://raw.githubusercontent.com/Linuxbrew/docker/master/centos6/Dockerfile
   ```
 + CentOS 7
   ```sh
-  docker build -t linuxbrew-centos7 https://raw.githubusercontent.com/Linuxbrew/docker/master/centos7/
+  docker build -t linuxbrew-centos7 https://raw.githubusercontent.com/Linuxbrew/docker/master/centos7/Dockerfile
   ```
 + Debian 9 (Stretch)
   ```sh
@@ -26,11 +26,11 @@ Dockerfiles for using Linuxbrew on various distributions of Linux.
   ```
 + Fedora 26
   ```sh
-  docker build -t linuxbrew-fedora https://raw.githubusercontent.com/Linuxbrew/docker/master/fedora/
+  docker build -t linuxbrew-fedora https://raw.githubusercontent.com/Linuxbrew/docker/master/fedora/Dockerfile
   ```
 + OpenSUSE 42
   ```sh
-  docker build -t linuxbrew-opensuse https://raw.githubusercontent.com/Linuxbrew/docker/master/opensuse/
+  docker build -t linuxbrew-opensuse https://raw.githubusercontent.com/Linuxbrew/docker/master/opensuse/Dockerfile
   ```
 + Travis CI
   ```sh
@@ -38,11 +38,11 @@ Dockerfiles for using Linuxbrew on various distributions of Linux.
   ```
 + Ubuntu 12.04 LTS (Precise Pangolin)
   ```sh
-  docker build -t linuxbrew-precise https://raw.githubusercontent.com/Linuxbrew/docker/master/precise/
+  docker build -t linuxbrew-precise https://raw.githubusercontent.com/Linuxbrew/docker/master/precise/Dockerfile
   ```
 + Ubuntu 14.04 LTS (Trusty Tahr)
   ```sh
-  docker build -t linuxbrew-trusty https://raw.githubusercontent.com/Linuxbrew/docker/master/trusty/
+  docker build -t linuxbrew-trusty https://raw.githubusercontent.com/Linuxbrew/docker/master/trusty/Dockerfile
   ```
 + Ubuntu 16.04 LTS (Xenial Xerus)
   ```sh


### PR DESCRIPTION
Title should be pretty self-explanatory. Provided instructions for some images are missing the word 'Dockerfile`. This PR fixes it