### PR TITLE
CentOS 5: Don't use urlgrabber

### DIFF
--- a/centos5/CentOS-Base.repo
+++ b/centos5/CentOS-Base.repo
@@ -1,0 +1,47 @@
+# CentOS-Base.repo
+#
+# The mirror system uses the connecting IP address of the client and the
+# update status of each mirror to pick mirrors that are updated to and
+# geographically close to the client.  You should use this for CentOS updates
+# unless you are manually picking other mirrors.
+#
+# If the mirrorlist= does not work for you, as a fall back you can try the 
+# remarked out baseurl= line instead.
+#
+#
+
+[base]
+name=CentOS-$releasever - Base
+baseurl=http://vault.centos.org/5.11/os/$basearch
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+
+#released updates 
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=http://vault.centos.org/5.11/updates/$basearch
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=http://vault.centos.org/5.11/extras/$basearch
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+
+#additional packages that extend functionality of existing packages
+[centosplus]
+name=CentOS-$releasever - Plus
+baseurl=http://vault.centos.org/5.11/centosplus/$basearch
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+
+#contrib - packages by Centos Users
+[contrib]
+name=CentOS-$releasever - Contrib
+baseurl=http://vault.centos.org/5.11/contrib/$basearch
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5

--- a/centos5/Dockerfile
+++ b/centos5/Dockerfile
@@ -3,9 +3,8 @@ LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="Linuxbrew/centos5"
 
 # Fix yum. CentOS 5 is end-of-life as of 2017-03-31.
-RUN urlgrabber https://gist.github.com/sjackman/132b65c33b62a89c45671e9c605025bc/raw/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo \
-	&& urlgrabber https://gist.github.com/sjackman/132b65c33b62a89c45671e9c605025bc/raw/libselinux.repo /etc/yum.repos.d/libselinux.repo \
-	&& yum install -y curl gcc gcc44 gcc44-c++ make sudo which \
+COPY CentOS-Base.repo libselinux.repo /etc/yum.repos.d/
+RUN yum install -y curl gcc gcc44 gcc44-c++ make sudo which \
 	&& yum clean all
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \

--- a/centos5/libselinux.repo
+++ b/centos5/libselinux.repo
@@ -1,0 +1,8 @@
+[libselinux]
+name=CentOS-$releasever - libselinux
+baseurl=http://vault.centos.org/5.11/centosplus/$basearch
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+includepkgs=libselinux*
+


### PR DESCRIPTION
This PR only partially fixes the CentOS 5 image. Currently, the build fails at the following command:

```
curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh
```