### PR TITLE
Fedora Dockerfile: use Fedora 28 and install file

### DIFF
--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -1,9 +1,9 @@
-FROM fedora:26
+FROM fedora:28
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="Linuxbrew/fedora"
 
-RUN dnf install -y curl git glibc-locale-source make ruby rubygem-json rubygem-test-unit sudo which \
-  && dnf clean all \
+RUN dnf install -y curl file git glibc-locale-source make ruby rubygem-json rubygem-test-unit sudo which \
+	&& dnf clean all \
 	&& localedef -i en_US -f UTF-8 en_US.UTF-8 \
 	&& useradd -m -s /bin/bash linuxbrew \
 	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers


### PR DESCRIPTION
- Use Fedora 28
- Install `file` (otherwise can't install anything with Homebrew)
- use tab