### PR TITLE
Fix build-breaking typo in precise Dockerfile

### DIFF
--- a/precise/Dockerfile
+++ b/precise/Dockerfile
@@ -4,7 +4,7 @@ LABEL name="linuxbrew/precise"
 
 RUN apt-get update \
 	&& apt-get install -y curl file g++ gawk git make sudo uuid-runtime \
-	&& apt-get-clean \
+	&& apt-get clean \
 	&& localedef -i en_US -f UTF-8 en_US.UTF-8 \
 	&& useradd -m -s /bin/bash linuxbrew \
 	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers


### PR DESCRIPTION
`s/apt-get-clean/apt-get clean/`