### PR TITLE
Add .dockerfilelintrc to skip false warnings about sudo

### DIFF
--- a/alpine/.dockerfilelintrc
+++ b/alpine/.dockerfilelintrc
@@ -1,0 +1,2 @@
+rules:
+    sudo_usage: off

--- a/centos5/.dockerfilelintrc
+++ b/centos5/.dockerfilelintrc
@@ -1,0 +1,2 @@
+rules:
+    sudo_usage: off

--- a/centos6/.dockerfilelintrc
+++ b/centos6/.dockerfilelintrc
@@ -1,0 +1,2 @@
+rules:
+    sudo_usage: off

--- a/centos7/.dockerfilelintrc
+++ b/centos7/.dockerfilelintrc
@@ -1,0 +1,2 @@
+rules:
+    sudo_usage: off

--- a/fedora/.dockerfilelintrc
+++ b/fedora/.dockerfilelintrc
@@ -1,0 +1,2 @@
+rules:
+    sudo_usage: off

--- a/opensuse/.dockerfilelintrc
+++ b/opensuse/.dockerfilelintrc
@@ -1,0 +1,2 @@
+rules:
+    sudo_usage: off

--- a/precise/.dockerfilelintrc
+++ b/precise/.dockerfilelintrc
@@ -1,0 +1,2 @@
+rules:
+    sudo_usage: off


### PR DESCRIPTION
Turn off false reports of _using_ `sudo` when we, in fact, install `sudo`...