### PR TITLE
alpine: Compile patchelf from source

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="linuxbrew/alpine"
 
 RUN apk update \
-	&& apk --no-cache add bash curl file git libc6-compat make ruby ruby-bigdecimal ruby-etc ruby-irb ruby-json ruby-test-unit sudo \
+	&& apk --no-cache add bash curl file g++ git libc6-compat make ruby ruby-bigdecimal ruby-etc ruby-irb ruby-json ruby-test-unit sudo \
 	&& adduser -D -s /bin/bash linuxbrew \
 	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
@@ -14,7 +14,13 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 	USER=linuxbrew
 
 RUN ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install)" \
-	&& HOMEBREW_NO_ANALYTICS=1 brew install --ignore-dependencies patchelf glibc \
+	&& HOMEBREW_NO_ANALYTICS=1 brew install -s patchelf \
+	&& HOMEBREW_NO_ANALYTICS=1 brew install --ignore-dependencies binutils gmp isl@0.18 libmpc linux-headers mpfr zlib \
+	&& (HOMEBREW_NO_ANALYTICS=1 brew install --ignore-dependencies gcc || true) \
+	&& HOMEBREW_NO_ANALYTICS=1 brew install glibc \
+	&& HOMEBREW_NO_ANALYTICS=1 brew postinstall gcc \
+	&& HOMEBREW_NO_ANALYTICS=1 brew remove patchelf \
+	&& HOMEBREW_NO_ANALYTICS=1 brew install -s patchelf \
 	&& HOMEBREW_NO_ANALYTICS=1 brew config
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Fix the error:
```
$ patchelf --version
Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /home/linuxbrew/.linuxbrew/bin/patchelf)
Error relocating /home/linuxbrew/.linuxbrew/bin/patchelf: __strftime_l: symbol not found
```

See https://github.com/Linuxbrew/docker/issues/58