### PR TITLE
Add missing git package to centos images

### DIFF
--- a/centos5/Dockerfile
+++ b/centos5/Dockerfile
@@ -5,7 +5,7 @@ LABEL name="linuxbrew/centos5"
 # Fix yum. CentOS 5 is end-of-life as of 2017-03-31.
 RUN urlgrabber https://gist.github.com/sjackman/132b65c33b62a89c45671e9c605025bc/raw/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo \
 	&& urlgrabber https://gist.github.com/sjackman/132b65c33b62a89c45671e9c605025bc/raw/libselinux.repo /etc/yum.repos.d/libselinux.repo \
-	&& yum install -y curl gcc gcc44 gcc44-c++ make sudo which \
+	&& yum install -y curl gcc gcc44 gcc44-c++ git make sudo which \
 	&& yum clean all
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \

--- a/centos6/Dockerfile
+++ b/centos6/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:6
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="linuxbrew/centos6"
 
-RUN yum install -y curl make sudo which \
+RUN yum install -y curl git make sudo which \
   && yum clean all
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \

--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="linuxbrew/centos7"
 
-RUN yum install -y curl file make ruby sudo which \
+RUN yum install -y curl file git make ruby sudo which \
   && yum clean all
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \


### PR DESCRIPTION
Dockerfiles of the images centos5, centos6, and centos7 are running `brew config` which need `git`.

The git package should then be added to these Dockerfiles.