### PR TITLE
alpine: use install script from Homebrew

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,19 +1,18 @@
-FROM alpine:20190925
+FROM alpine:3.11
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="linuxbrew/alpine"
 
 RUN apk update \
-	&& apk --no-cache add bash curl file g++ git libc6-compat make ruby ruby-bigdecimal ruby-etc ruby-irb ruby-json ruby-test-unit sudo \
+	&& apk --no-cache add bash coreutils curl file g++ grep git libc6-compat make ruby ruby-bigdecimal ruby-etc ruby-irb ruby-json ruby-test-unit sudo \
 	&& adduser -D -s /bin/bash linuxbrew \
-	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
-
+	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers \
+	&& ln -s /bin/touch /usr/bin/touch
 USER linuxbrew
 WORKDIR /home/linuxbrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 	SHELL=/bin/bash \
 	USER=linuxbrew
-
-RUN ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install)" \
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 	&& HOMEBREW_NO_ANALYTICS=1 brew install -s patchelf \
 	&& HOMEBREW_NO_ANALYTICS=1 brew install --ignore-dependencies binutils gmp isl@0.18 libmpc linux-headers mpfr zlib \
 	&& (HOMEBREW_NO_ANALYTICS=1 brew install --ignore-dependencies gcc || true) \
@@ -22,5 +21,4 @@ RUN ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/ma
 	&& HOMEBREW_NO_ANALYTICS=1 brew remove patchelf \
 	&& HOMEBREW_NO_ANALYTICS=1 brew install -s patchelf \
 	&& HOMEBREW_NO_ANALYTICS=1 brew config
-
 CMD ["/bin/bash"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -7,11 +7,13 @@ RUN apk update \
 	&& adduser -D -s /bin/bash linuxbrew \
 	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers \
 	&& ln -s /bin/touch /usr/bin/touch
+
 USER linuxbrew
 WORKDIR /home/linuxbrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 	SHELL=/bin/bash \
 	USER=linuxbrew
+
 RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 	&& HOMEBREW_NO_ANALYTICS=1 brew install -s patchelf \
 	&& HOMEBREW_NO_ANALYTICS=1 brew install --ignore-dependencies binutils gmp isl@0.18 libmpc linux-headers mpfr zlib \
@@ -21,4 +23,5 @@ RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/instal
 	&& HOMEBREW_NO_ANALYTICS=1 brew remove patchelf \
 	&& HOMEBREW_NO_ANALYTICS=1 brew install -s patchelf \
 	&& HOMEBREW_NO_ANALYTICS=1 brew config
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
Use the install script
```
https://raw.githubusercontent.com/Homebrew/install/master/install.sh
```
instead of
```
https://raw.githubusercontent.com/Linuxbrew/install/master/install
```
The Homebrew install script needs the coreutils and the grep alpine packages. Alpine use by default busybox commands and some needed options are missing in these commands.

A symbolic link from `/usr/bin/touch` touch to `/bin/touch` has been created and the Alpine version has been set to 3.11

The Apache Tomcat server have been successfully installed and run with Homebrew.