### PR TITLE
Bionic: remove redundant `apt-get clean` step

### DIFF
--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -5,7 +5,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl file g++ git locales make uuid-runtime \
-    && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -f UTF-8 en_US.UTF-8 \
     && useradd -m -s /bin/bash linuxbrew \


### PR DESCRIPTION
From https://docs.docker.com/develop/develop-images/dockerfile_best-practices:

> Official Debian and Ubuntu images automatically run apt-get clean,
so explicit invocation is not required.