### PR TITLE
alpine: Reinstate a line continuation to silence `dockerfilelint`

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -14,7 +14,7 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 	SHELL=/bin/bash \
 	USER=linuxbrew
 
-RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" \
 	&& HOMEBREW_NO_ANALYTICS=1 brew install -s patchelf \
 	&& HOMEBREW_NO_ANALYTICS=1 brew install --ignore-dependencies binutils gmp isl@0.18 libmpc linux-headers mpfr zlib \
 	&& (HOMEBREW_NO_ANALYTICS=1 brew install --ignore-dependencies gcc || true) \


### PR DESCRIPTION
- I'm surprised this worked to build (I didn't test it), I just saw the `dockerfilelint` error:

```
File:   alpine/Dockerfile
Issues: 1

Line 18: 	&& HOMEBREW_NO_ANALYTICS=1 brew install -s patchelf \
Issue  Category      Title                 Description
    1  Possible Bug  Invalid Command       Only valid commands are allowed in a Dockerfile.
```

----

This only silences one of the two Dockerfilelint errors. The [documented syntax for ignoring rules](https://github.com/replicatedhq/dockerfilelint#configuring)  doesn't appear to work. I tried making a `.dockerfilelintrc` with:

```yaml
rules:
  latest_tag: off
```

to no avail. Oh well! I figured at this point if we've not fixed it then best ignore it!