### PR TITLE
fedora: use install script from Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ docker run -it linuxbrew/debian9
 docker run -it linuxbrew/debian10
 ```
 
-## Fedora 28
+## Fedora 31
 ```sh
 docker build -t linuxbrew-fedora https://raw.githubusercontent.com/Linuxbrew/docker/master/fedora/Dockerfile
 ```

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -1,8 +1,8 @@
-FROM fedora:28
+FROM fedora:31
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="linuxbrew/fedora"
 
-RUN dnf install -y curl file git glibc-locale-source make ruby rubygem-json rubygem-test-unit sudo which \
+RUN dnf install -y curl file gcc git glibc-locale-source make ruby rubygem-json rubygem-test-unit sudo which \
 	&& dnf clean all \
 	&& localedef -i en_US -f UTF-8 en_US.UTF-8 \
 	&& useradd -m -s /bin/bash linuxbrew \
@@ -14,7 +14,7 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 	SHELL=/bin/bash \
 	USER=linuxbrew
 
-RUN yes | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install)" \
+RUN yes | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" \
 	&& brew config
 
 CMD ["/bin/bash"]

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:31
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="linuxbrew/fedora"
 
-RUN dnf install -y curl file gcc git glibc-locale-source make ruby rubygem-json rubygem-test-unit sudo which \
+RUN dnf install -y curl file git glibc-locale-source make ruby rubygem-json rubygem-test-unit sudo which \
 	&& dnf clean all \
 	&& localedef -i en_US -f UTF-8 en_US.UTF-8 \
 	&& useradd -m -s /bin/bash linuxbrew \

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -14,7 +14,7 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 	SHELL=/bin/bash \
 	USER=linuxbrew
 
-RUN yes | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" \
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" \
 	&& brew config
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Use the install script
```
https://raw.githubusercontent.com/Homebrew/install/master/install.sh
```
instead of
```
https://raw.githubusercontent.com/Linuxbrew/install/master/install
```
- The fedora base image has been upgraded to fedora:31 (latest)
- The gcc package have been added to the image to avoid the following scenario:
```
[linuxbrew@8c7d4df6f7e3 ~]$ brew install gcc
==> Installing dependencies for gcc: patchelf, gmp, mpfr, libmpc, zlib, binutils and isl@0.18
==> Installing gcc dependency: patchelf
==> Downloading https://linuxbrew.bintray.com/bottles/patchelf-0.10.x86_64_linux.bottle.tar.gz
Already downloaded: /home/linuxbrew/.cache/Homebrew/downloads/405227c46362964d2bc2e9ff6428fe082dff4dbd3a4b0b29453743f71923304b--patchelf-0.10.x86_64_linux.bottle.tar.gz
==> Pouring patchelf-0.10.x86_64_linux.bottle.tar.gz
Error: patchelf must be installed: brew install patchelf
Warning: Bottle installation failed: building from source.
Error: The following formula
  patchelf
cannot be installed as binary package and must be built from source.
Install Clang or run `brew install gcc`.
```