### PR TITLE
ci: Run on Linux, not macOS, as the Actions Linux runners have Homebrew

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -2,7 +2,7 @@ name: Lint all Dockerfiles
 on: [push, pull_request]
 jobs:
   lint:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: brew install hadolint


### PR DESCRIPTION
- It always felt odd to be running the checks on macOS for a repo in the _Linuxbrew_ org.