### PR TITLE
alpine: add ruby-fiddle

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 LABEL name="linuxbrew/alpine"
 
 RUN apk update \
-	&& apk --no-cache add bash coreutils curl file g++ grep git libc6-compat make ruby ruby-bigdecimal ruby-etc ruby-irb ruby-json ruby-test-unit sudo \
+	&& apk --no-cache add bash coreutils curl file g++ grep git libc6-compat make ruby ruby-bigdecimal ruby-etc ruby-fiddle ruby-irb ruby-json ruby-test-unit sudo \
 	&& adduser -D -s /bin/bash linuxbrew \
 	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers \
 	&& ln -s /bin/touch /usr/bin/touch


### PR DESCRIPTION
Solves:

```
/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- fiddle (LoadError)
	from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
```